### PR TITLE
FEAT query-record and query-all added

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Usage
 {{#each (store/find-all 'user') as |user|}}
   {{user.name}}
 {{/each}}
+
+{{#each (store/query-all 'user' (hash name='John')) as |john|}}
+  John at age {{user.age}}
+{{/each}}
+
+{{#let (store/query-record 'setting' (hash key='uniqueKey')) as |setting|}}
+  {{setting.name}}: {{setting.value}}
+{{/let}}
 ```
 
 

--- a/addon/helpers/store/query-all.js
+++ b/addon/helpers/store/query-all.js
@@ -1,0 +1,15 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
+
+export default Helper.extend({
+  store: service(),
+
+  compute([type, query]) {
+    if (isEmpty(query)) {
+      query = {}
+    }
+
+    return this.get('store').query(type, query);
+  }
+});

--- a/addon/helpers/store/query-record.js
+++ b/addon/helpers/store/query-record.js
@@ -1,0 +1,15 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+import { isEmpty } from '@ember/utils';
+
+export default Helper.extend({
+  store: service(),
+
+  compute([type, query]) {
+    if (isEmpty(query)) {
+      return null;
+    }
+
+    return this.get('store').queryRecord(type, query);
+  }
+});

--- a/app/helpers/store/query-all.js
+++ b/app/helpers/store/query-all.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-store-helpers/helpers/store/query-all';

--- a/app/helpers/store/query-record.js
+++ b/app/helpers/store/query-record.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-store-helpers/helpers/store/query-record';

--- a/tests/integration/helpers/store/query-all-test.js
+++ b/tests/integration/helpers/store/query-all-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Model from 'ember-data/model';
+import Adapter from 'ember-data/adapter';
+import attr from 'ember-data/attr';
+
+module('Integration | Helper | store/query-all', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('model:user', Model.extend({
+      name: attr()
+    }));
+
+    this.owner.register('adapter:user', Adapter.extend({
+      async query(_store, _type, query) {
+        const data = [
+          {id: 1, name: '1mura'},
+          {id: 2, name: '2mura'},
+          {id: 3, name: '3mura'},
+          {id: 4, name: '1mura'},
+        ]
+        return data.filter( (rec) => rec.name === query.query.name )
+      }
+    }));
+  });
+
+  test('it works', async function(assert) {
+    await render(hbs`{{join ', ' (map-by 'name' (store/query-all 'user' (hash query=(hash name="1mura"))))}}`);
+
+    assert.equal(this.element.textContent.trim(), '1mura, 1mura');
+  });
+});

--- a/tests/integration/helpers/store/query-record-test.js
+++ b/tests/integration/helpers/store/query-record-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Model from 'ember-data/model';
+import Adapter from 'ember-data/adapter';
+import attr from 'ember-data/attr';
+
+module('Integration | Helper | store/find-record', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register('model:user', Model.extend({
+      name: attr()
+    }));
+
+    this.owner.register('adapter:user', Adapter.extend({
+      async queryRecord(_store, _type, query) {
+        return {id: query.id, name: 'takkanm'};
+      }
+    }));
+  });
+
+  test('it works', async function(assert) {
+    await render(hbs`{{get (store/query-record 'user' (hash id=42)) 'name'}}`);
+
+    assert.equal(this.element.textContent.trim(), 'takkanm');
+  });
+
+  test('it returns null if id is empty value', async function(assert) {
+    await render(hbs`{{eq (store/query-record 'user' null) null}}`);
+    assert.equal(this.element.textContent.trim(), 'true');
+
+    await render(hbs`{{eq (store/query-record 'user' undefined) null}}`);
+    assert.equal(this.element.textContent.trim(), 'true');
+
+    await render(hbs`{{eq (store/query-record 'user' '') null}}`);
+    assert.equal(this.element.textContent.trim(), 'true');
+  });
+});


### PR DESCRIPTION
Hi, I noticed that adapter.query and adapter.queryRecord are not yet supported, should work with this PR. Feedback appreciated.